### PR TITLE
fix(package/crossplane.yaml): fix the URL in the pkg metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ using either of the following methods:
 
 - Using [up](https://docs.upbound.io/reference/cli/):
   ```bash
-  up ctp provider install crossplane-contrib/provider-spotify:v0.2.0
+  up ctp provider install crossplane-contrib/provider-spotify:v0.2.2
   ```
 
 - Using [crossplane](https://docs.crossplane.io/latest/cli/):
   ```bash
-  crossplane xpkg install provider crossplane-contrib/provider-spotify:v0.2.0
+  crossplane xpkg install provider crossplane-contrib/provider-spotify:v0.2.2
   ```
 
 - Using declarative installation:

--- a/examples/install.yaml
+++ b/examples/install.yaml
@@ -3,4 +3,4 @@ kind: Provider
 metadata:
   name: provider-spotify
 spec:
-  package: crossplane-contrib/provider-spotify:v0.2.0
+  package: crossplane-contrib/provider-spotify:v0.2.2

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -4,7 +4,7 @@ metadata:
   name: provider-spotify
   annotations:
     meta.crossplane.io/maintainer: "Theo Chatzimichos <tampakrap@gmail.com>"
-    meta.crossplane.io/source: https://github.com/crossplane-contrib/provider-spotify
+    meta.crossplane.io/source: github.com/crossplane-contrib/provider-spotify
     meta.crossplane.io/license: Apache-2.0
     meta.crossplane.io/description: A Crossplane provider for managing Spotify playlists in Kubernetes.
     meta.crossplane.io/readme: |


### PR DESCRIPTION
The marketplace UI is creating a wrong URL when the "https://" part is
present in the pkg metadata, it generates the following invalid URL:

```
https://https//github.com/ORG/PROVIDER
```

Removing the "https://" from the pkg metadata fixes the issue, as
confirmed by looking at the pkg metadata of other providers.