### PR TITLE
ci: run the publish-artifacts job last

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,13 @@ jobs:
 
   publish-artifacts:
     runs-on: ubuntu-22.04
-    needs: detect-noop
+    needs:
+      - detect-noop
+      - report-breaking-changes
+      - lint
+      - check-diff
+      - unit-tests
+      - local-deploy
     if: needs.detect-noop.outputs.noop != 'true'
 
     steps:


### PR DESCRIPTION
I prefer not to publish any artifacts/images if the tests
(lint/unit/others) are failing.