### PR TITLE
Enforce maximum allowed Terraform version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ export TERRAFORM_VERSION ?= 1.5.7
 
 # Do not allow a version of terraform greater than 1.5.x, due to versions 1.6+ being
 # licensed under BSL, which is not permitted.
-export TERRAFORM_VERSION_CEILING ?= 1.6
-TERRAFORM_VERSION_VALID := $(shell [ $(TERRAFORM_VERSION) = `echo "$(TERRAFORM_VERSION)\n$(TERRAFORM_VERSION_CEILING)" | sort -V | head -n1` ] && echo 1 || echo 0)
+TERRAFORM_VERSION_VALID := $(shell [ "$(TERRAFORM_VERSION)" = "`printf "$(TERRAFORM_VERSION)\n1.6" | sort -V | head -n1`" ] && echo 1 || echo 0)
 
 export TERRAFORM_PROVIDER_SOURCE ?= conradludgate/spotify
 export TERRAFORM_PROVIDER_REPO ?= https://github.com/conradludgate/terraform-provider-spotify
@@ -107,7 +106,7 @@ TERRAFORM_PROVIDER_SCHEMA := config/schema.json
 
 check-terraform-version:
 ifneq ($(TERRAFORM_VERSION_VALID),1)
-	$(error invalid TERRAFORM_VERSION $(TERRAFORM_VERSION), must be less than $(TERRAFORM_VERSION_CEILING))
+	$(error invalid TERRAFORM_VERSION $(TERRAFORM_VERSION), must be less than 1.6.0 since that version introduced a not permitted BSL license))
 endif
 
 $(TERRAFORM): check-terraform-version


### PR DESCRIPTION
### Description of your changes

This PR applies the changes from https://github.com/crossplane/upjet-provider-template/pull/67 to this repository.

In the Crossplane project, we cannot use a version of Terraform greater than v1.5.x because of the not permitted BSL license that was introduced starting with v1.6.0.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have tested locally that the build still completes successful with `make` and `make reviewable` still passes all tests/checks. Of particular note is that no CRD schemas are affected by this change.

I would appreciate a critical look here to see if there's more manual testing we can perform to validate this change, as I am rolling this out across a number of providers I'm not super familiar with 😇 

[contribution process]: https://git.io/fj2m9
