### PR TITLE
build: pass robot token credentials for publishing to mirror registry

### DIFF
--- a/.github/workflows/publish-provider-package.yaml
+++ b/.github/workflows/publish-provider-package.yaml
@@ -16,10 +16,11 @@ jobs:
   publish-provider-package:
     uses: crossplane-contrib/provider-workflows/.github/workflows/publish-provider-non-family.yml@main
     with:
-      repository: provider-upjet-spotify
+      repository: provider-spotify
       version: ${{ github.event.inputs.version }}
       go-version: ${{ github.event.inputs.go-version }}
       cleanup-disk: true
     secrets:
       GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
-      XPKG_UPBOUND_TOKEN: ${{ secrets.XPKG_TOKEN }}
+      XPKG_MIRROR_TOKEN: ${{ secrets.XPKG_TOKEN }}
+      XPKG_MIRROR_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}


### PR DESCRIPTION
### Description of your changes

This PR updates the publishing workflow to pass robot token credentials to the reusable workflow. The workflow was updated to explicitly expect robot tokens in https://github.com/crossplane-contrib/provider-workflows/pull/15/.

It also updates the repository name to the correct one as pointed out by @tampakrap 😇 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

We will test this in publishing from main after this is merged.

[contribution process]: https://git.io/fj2m9
